### PR TITLE
handle artifactory urls in project.clj, update env var handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.enableFiletypes": [
+        "!python"
+    ]
+}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# add security team as a reviewer for all files 
+* @puppetlabs/security

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,16 @@
-FROM openjdk:11-slim-bullseye
+#FROM openjdk:11-slim-bullseye
+FROM clojure:openjdk-11-lein-bullseye
 # move into the puppet directory
 RUN mkdir -p /puppet/
 ADD clojure_action.py /puppet/clojure_action
 RUN chmod 751 /puppet/clojure_action
-# download leiningen
-ADD https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein /puppet/lein.sh
-RUN chmod 751 /puppet/lein.sh
 # download the snyk CLI
 ADD https://github.com/snyk/snyk/releases/download/v1.720.0/snyk-linux /puppet/snyk 
 RUN chmod 751 /puppet/snyk 
 # add puppet to the path
 ENV PATH="/puppet/:${PATH}"
-#lein needs wget, snyk needs maven, we need python3
+# we need maven to support snyk
 RUN apt update
-RUN apt install wget maven python3 -y
+RUN apt install maven -y
 # run the action
 CMD [ "clojure_action" ]

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
+# testFolder = pe-puppet-server-extensions
+# testFolder = code-manager
+testFolder = clj-parent
+
 delete:
 	-docker rm clojure_action
 build:
 	docker build -t clojure_action .
 copy_testfiles:
-	-rm -rf ./testfiles/pe-puppet-server-extensions
-	-mkdir -p ./testfiles/pe-puppet-server-extensions
-	cp -r /Users/jeremy.mill/Documents/forks/pe-puppet-server-extensions/ ./testfiles/pe-puppet-server-extensions
+	-rm -rf ./testfiles/$(testFolder)
+	-mkdir -p ./testfiles/$(testFolder)
+	cp -r /Users/jeremy.mill/Documents/forks/$(testFolder)/ ./testfiles/$(testFolder)
 
 itest:
 	make delete
@@ -17,13 +21,14 @@ itest:
 		-e INPUT_SNYKTOKEN=$(SNYK_TOKEN) \
 		-e GITHUB_WORKSPACE=/github/workspace \
 		-e INPUT_RPROXYKEY=$(RPROXY_KEY) \
-		-v "/Users/jeremy.mill/Documents/security-snyk-clojure-action/testfiles/pe-puppet-server-extensions":"/github/workspace" \
+		-e INPUT_NOMONITOR=true \
+		-v "/Users/jeremy.mill/Documents/security-snyk-clojure-action/testfiles/$(testFolder)":"/github/workspace" \
 		-t clojure_action 
 itest_ignore:
 	make delete
 	make build
 	make copy_testfiles
-	cp ./testfiles/.snyk ./testfiles/pe-puppet-server-extensions/
+	cp ./testfiles/.snyk ./testfiles/$(testFolder)/
 	docker run --name clojure_action \
 		-e INPUT_SNYKORG=sectest \
 		-e INPUT_SNYKPROJECT=puppetserver \
@@ -32,7 +37,7 @@ itest_ignore:
 		-e INPUT_RPROXYKEY=$(RPROXY_KEY) \
 		-e INPUT_NOMONITOR=true \
 		-e INPUT_SNYKPOLICY=.snyk \
-		-v "/Users/jeremy.mill/Documents/security-snyk-clojure-action/testfiles/pe-puppet-server-extensions":"/github/workspace" \
+		-v "/Users/jeremy.mill/Documents/security-snyk-clojure-action/testfiles/$(testFolder)":"/github/workspace" \
 		-t clojure_action 
 exec:
 	make delete
@@ -43,5 +48,5 @@ exec:
 		-e INPUT_SNYKTOKEN=$(SNYK_TOKEN) \
 		-e GITHUB_WORKSPACE=/github/workspace \
 		-e INPUT_RPROXYKEY=$(RPROXY_KEY) \
-		-v "/Users/jeremy.mill/Documents/security-snyk-clojure-action/testfiles/pe-puppet-server-extensions":"/github/workspace" \
+		-v "/Users/jeremy.mill/Documents/security-snyk-clojure-action/testfiles/$(testFolder)":"/github/workspace" \
 		-it clojure_action /bin/bash

--- a/private_sample_workflow.yaml
+++ b/private_sample_workflow.yaml
@@ -4,7 +4,7 @@ name: snyk_pr
 on: [pull_request_target]
 
 jobs:
- snyk_vanagon:
+ snyk_scan:
    runs-on: ubuntu-latest
    steps:
     - name: checkout the current PR
@@ -14,7 +14,7 @@ jobs:
         persist-credentials: false
     - name: Run Clojure Snyk Scan
       id: scan
-      uses: puppetlabs/security-snyk-clojure-action@v1.2.0
+      uses: puppetlabs/security-snyk-clojure-action@main
       with:
         snykToken: ${{ secrets.SNYK_PE_TOKEN }}
         rproxyKey: ${{ secrets.SEC_RPROXY_KEY }}

--- a/public_sample_workflow.yaml
+++ b/public_sample_workflow.yaml
@@ -6,7 +6,7 @@ on:
     types: [labeled]
 
 jobs:
- snyk_vanagon:
+ snyk_scan:
    runs-on: ubuntu-latest
    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
    steps:
@@ -17,7 +17,7 @@ jobs:
         persist-credentials: false
     - name: Run Clojure Snyk Scan
       id: scan
-      uses: puppetlabs/security-snyk-clojure-action@v0.0.1
+      uses: puppetlabs/security-snyk-clojure-action@main
       with:
         snykToken: ${{ secrets.SNYK_TOKEN }}
         rproxyKey: ${{ secrets.RPROXY_KEY }}


### PR DESCRIPTION
This handles artifactory URLs in locations like:

```clojure
  :repositories [["releases" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-releases__local/"]
                 ["snapshots" "https://artifactory.delivery.puppetlabs.net/artifactory/clojure-snapshots__local/"]]
```

It also handles the env var reading to make it a bit easier to read. It also makes changing the makefile easier. It also adds a codeowners. 