### PR TITLE
Set project name by default using env variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ This input is the secret snyk token
 ### snykOrg (not required)
 The organization in snyk to send results to
 
-### snykProject (not required)
-The project name in snyk
-
 ### noMonitor (not required)
 If you just want to run `snyk test` and not `snyk monitor` you should set this input to `true`
 

--- a/action.yaml
+++ b/action.yaml
@@ -10,9 +10,6 @@ inputs:
   snykOrg:
     description: 'snyk org to write results to'
     required: false
-  snykProject:
-    description: 'snyk project to write results to'
-    required: false
   snykPolicy:
     description: 'the path to a .snyk file (https://docs.snyk.io/features/fixing-and-prioritizing-issues/policies/the-.snyk-file)'
     required: false

--- a/clojure_action.py
+++ b/clojure_action.py
@@ -8,7 +8,6 @@ import json
 OPT_ARGS = {
     'INPUT_SNYKPOLICY': '--policy-path={evar}',
     'INPUT_SNYKORG': '--org={evar}',
-    'INPUT_SNYKPROJECT': '--project-name={evar}'
 }
 
 class AuthError(Exception):
@@ -96,8 +95,14 @@ def _getArgs():
     if additional_args:
         logging.info(f'adding additional snyk args: {additional_args}')
         snykArgs = snykArgs + additional_args.split(' ')
+    
+    # this returns "puppetlabs/<repo-name>"
     repo_name = os.getenv("GITHUB_REPOSITORY")
     snykArgs.append(f'--remote-repo-url=https://github.com/{repo_name}')
+    # format project name for the snyk dashboard report
+    # TODO: come up with better approach then hardcoding 'puppetlabs/'
+    proj_name = repo_name.replace('puppetlabs/', '')
+    snykArgs.append(f'--project-name={proj_name}')
     target_ref = bool(os.getenv("INPUT_SNYKTARGETREF"))
     if target_ref:
         branch_name = os.getenv("GITHUB_REF_NAME")
@@ -222,5 +227,4 @@ if __name__ == "__main__":
     print(output)
     fo = _getOutput('failure', 'false')
     print(fo)
-    
     


### PR DESCRIPTION
Set the repository name as project name by default to prevent mismatches with the dashboard reporting script.