### PR TITLE
Let default values be overriden from inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ The organization in snyk to send results to
 ### snykProject (not required)
 The project name in snyk
 
+### snykRepo (not required)
+Set this if you want to group under different repository in Snyk.
+
 ### noMonitor (not required)
 If you just want to run `snyk test` and not `snyk monitor` you should set this input to `true`
 

--- a/action.yaml
+++ b/action.yaml
@@ -13,6 +13,9 @@ inputs:
   snykProject:
     description: 'snyk project to write results to'
     required: false
+  snykRepo:
+    description: 'snyk repo to group the projects in'
+    required: false
   snykPolicy:
     description: 'the path to a .snyk file (https://docs.snyk.io/features/fixing-and-prioritizing-issues/policies/the-.snyk-file)'
     required: false

--- a/clojure_action.py
+++ b/clojure_action.py
@@ -100,13 +100,13 @@ def _getArgs():
     
     # this returns "puppetlabs/<repo-name>"
     repo_name = os.getenv("GITHUB_REPOSITORY")
-    snyk_repo = bool(os.getenv("INPUT_SNYKREPO"))
+    snyk_repo = os.getenv("INPUT_SNYKREPO")
     # set to default repo name if not specified
-    if not snyk_repo:
+    if snyk_repo == '':
         snykArgs.append(f'--remote-repo-url=https://github.com/{repo_name}')
-    snyk_proj = bool(os.getenv("INPUT_SNYKPROJECT"))
+    snyk_proj = os.getenv("INPUT_SNYKPROJECT")
     # set to default project name if not specified
-    if not snyk_proj:
+    if snyk_proj == '':
         # get the repo name without the owner name
         proj_name = repo_name.split('/')[1]
         snykArgs.append(f'--project-name={proj_name}')

--- a/clojure_action.py
+++ b/clojure_action.py
@@ -8,7 +8,8 @@ import json
 OPT_ARGS = {
     'INPUT_SNYKPOLICY': '--policy-path={evar}',
     'INPUT_SNYKORG': '--org={evar}',
-    'INPUT_SNYKPROJECT': '--project-name={evar}'
+    'INPUT_SNYKPROJECT': '--project-name={evar}',
+    'INPUT_SNYKREPO': '--remote-repo-url={evar}'
 }
 
 class AuthError(Exception):
@@ -96,8 +97,19 @@ def _getArgs():
     if additional_args:
         logging.info(f'adding additional snyk args: {additional_args}')
         snykArgs = snykArgs + additional_args.split(' ')
+    
+    # this returns "puppetlabs/<repo-name>"
     repo_name = os.getenv("GITHUB_REPOSITORY")
-    snykArgs.append(f'--remote-repo-url=https://github.com/{repo_name}')
+    snyk_repo = bool(os.getenv("INPUT_SNYKREPO"))
+    # set to default repo name if not specified
+    if not snyk_repo:
+        snykArgs.append(f'--remote-repo-url=https://github.com/{repo_name}')
+    snyk_proj = bool(os.getenv("INPUT_SNYKPROJECT"))
+    # set to default project name if not specified
+    if not snyk_proj:
+        # get the repo name without the owner name
+        proj_name = repo_name.split('/')[1]
+        snykArgs.append(f'--project-name={proj_name}')
     target_ref = bool(os.getenv("INPUT_SNYKTARGETREF"))
     if target_ref:
         branch_name = os.getenv("GITHUB_REF_NAME")
@@ -222,5 +234,4 @@ if __name__ == "__main__":
     print(output)
     fo = _getOutput('failure', 'false')
     print(fo)
-    
     


### PR DESCRIPTION
This will allow the user to set project name and repo name in the actions inputs. The default value is the name of the repo the action is triggered from.